### PR TITLE
Fixing issues with non-latin characters and trackNum == 0

### DIFF
--- a/xspf_lib/__init__.py
+++ b/xspf_lib/__init__.py
@@ -21,6 +21,14 @@ def quote(value: str) -> str:
     return value
 
 
+def quoteInvalidChars(value: str) -> str:   # introduced by @gdalik
+    _value = ''
+    for char in value:
+        _char = char if char in _Parser.uric else urlparse.quote(char)
+        _value += _char
+    return _value
+
+
 class XMLAble(ABC):
 
     @abstractmethod
@@ -279,8 +287,8 @@ class Track(XMLAble):
     @trackNum.setter
     def trackNum(self, value: int) -> None:
         if value is not None:
-            if value <= 0:
-                raise ValueError("trackNum must be greater than zero.\n"
+            if value < 0:   # modified by @gdalik in order to include trackNum == 0
+                raise ValueError("trackNum must be positive number.\n"
                                  "| Expected: {1, 2, ..}\n"
                                  f"| Got: {value}")
             self.__trackNum = value
@@ -633,6 +641,7 @@ class _Parser():
 
     @staticmethod
     def urify(value):
+        value = quoteInvalidChars(value)    # introduced by @gdalik
         if all(char in _Parser.uric for char in value):
             return value
         else:


### PR DESCRIPTION
Hi @dem214!

Thank you for your library. It's really useful for the project I'm currently working on. I have faced with a couple of issues.

The first one appears when a path to an XSPF file stored locally contains non-Latin (e.g. Cyrillic) characters. The `urify` static method of the `_Parser` class raises the ValueError, and the parsing process just crashes. I'm not a specialist in encoding formats, and I'm not sure if this is the real solution or just a workaround to bypass the problem, but the function that quotes these characters which I introduced lets the correct local paths of this kind be read/parsed at least.

And the second issue is about track numbers (`trackNum`) with zero values. Some popular players (e.g., AIMP) export XSPF files with them, and then load\read them flawlessly. However, in your current version the `trackNum.setter` method raises ValueError for these playlists, and the parsing crashes as well. Modifying the condition, triggering this error, from `value <= 0` to 'value < 0' made it work for me.

I would be grateful for your feedback/suggestions/improvements.

Thanks again!